### PR TITLE
feat: Generalized Italian Attribute Authority use case

### DIFF
--- a/multi-subject-jwt/draft-yusef-oauth-nested-jwt-06.xml
+++ b/multi-subject-jwt/draft-yusef-oauth-nested-jwt-06.xml
@@ -191,16 +191,19 @@
   </t>
   </section>
     
-  <section anchor="multiple-aas" numbered="true" toc="default">
-  <name>Multiple Attribute Authorities</name>
+  <section anchor="multiple-audiences" numbered="true" toc="default">
+  <name>Multiple tokens for multiple resources</name>
   <t>
-     A JWT may have embedded tokens from one or more Attribute Authorities. 
+     A JWT may embeds tokens for different audiences and scopes. 
   </t>
   <t>
-  An ID Token may have multiple special tokens to be used by the client to contact the OP to obtain access tokens.
+  An Authorization Server issues a JWT Token that contains multiple tokens. 
+  Each token has a specialized set of attributes and values.
+  The tokens can be used by the client to consume protected resources or to obtain access tokens through 
+  a token exchange mechanism, over different domains, releasing the minimum possible number 
+  of information, related on the main subject, necessary for the operation. 
   </t>
   </section>
-
 
       </section>
     </section>


### PR DESCRIPTION
In this PR I tried to generalize the italian attribute authorities architecture as a general use case not too much linked to the italian implementation.

this solution fits very well the italian implementation without forcing any implementative choice, like the choice of transporting the embedded tokens in the ID Token. The embedded tokens in the italian implementation have a subset of the values of the parent token and other specialized claims/values for specialized audiences and scopes.

an important mention was also made for the data minimization principle, where the embedded token fullfil the requirement of disclosing only the minim set of required information for the operation