### PR TITLE
feat: github page CD

### DIFF
--- a/.github/workflows/xml2rfc.yml
+++ b/.github/workflows/xml2rfc.yml
@@ -44,7 +44,7 @@ jobs:
         run: python3 -m pip install xml2rfc
       
       - name: build the page
-      - run: mkdir -p build && xml2rfc openid-connect-federation-1_0.xml --html -o build/index.html
+      - run: mkdir -p build && xml2rfc draft-yusef-oauth-nested-jwt-*.xml --html -o build/index.html
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3


### PR DESCRIPTION
Github page continuous deployment with xml2rfc using [peaceiris/actions-gh](https://github.com/peaceiris/actions-gh-pages#%EF%B8%8F-static-site-generators-with-python)

requirements:

- [ ] GITHUB_TOKEN (Note: GitHub already creates one for you by default)
- [ ] enable github pages deployments